### PR TITLE
vcs: fix router random 404 errors on start

### DIFF
--- a/pkg/app.go
+++ b/pkg/app.go
@@ -17,11 +17,7 @@ type App struct {
 }
 
 func New(config *config.Config, router *mux.Router) *App {
-	// todo(while-loop):  fix router random 404 errors on start
-
-	rp := vcs.NewManager(config.VcsConfig)
-	rp.ApplyRouter(router)
-
+	rp := vcs.NewManager(config.VcsConfig, router)
 	return &App{
 		RepoMan:    rp,
 		TrackerMan: tracker.NewManager(config.TrackerConfig, rp.IssueChan()),

--- a/pkg/vcs/github/github.go
+++ b/pkg/vcs/github/github.go
@@ -48,17 +48,12 @@ func NewService(config *config.GithubConfig, issueChan chan<- []*issue.Issue) *S
 	return s
 }
 
-func (s *Service) GetRepository(user, project string) error {
-	panic("implement me")
-}
-
 func (s *Service) Name() string {
 	return name
 }
 
-func (s *Service) Handler() http.Handler {
-	s.router.HandleFunc("/webhook/"+name, s.webhook).Methods("POST")
-	return s.router
+func (s *Service) Init(webhookRouter *mux.Router) {
+	webhookRouter.HandleFunc("/"+name, s.webhook).Methods("POST")
 }
 
 func (s *Service) webhook(w http.ResponseWriter, r *http.Request) {

--- a/pkg/vcs/gitlab/gitlab.go
+++ b/pkg/vcs/gitlab/gitlab.go
@@ -31,17 +31,12 @@ func NewService(config *config.GitlabConfig, issueChan <-chan []*issue.Issue) *S
 	return s
 }
 
-func (s *Service) GetRepository(user, project string) error {
-	panic("implement me")
-}
-
 func (s *Service) Name() string {
 	return name
 }
 
-func (s *Service) Handler() http.Handler {
-	s.router.HandleFunc("/webhook/"+name, s.webhook)
-	return s.router
+func (s *Service) Init(webhookRouter *mux.Router) {
+	webhookRouter.HandleFunc("/"+name, s.webhook).Methods("POST")
 }
 
 func (s *Service) webhook(w http.ResponseWriter, r *http.Request) {

--- a/pkg/vcs/manager_test.go
+++ b/pkg/vcs/manager_test.go
@@ -1,0 +1,51 @@
+package vcs
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/while-loop/todo/pkg/vcs/config"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testVCS struct{}
+
+func (t *testVCS) Name() string {
+	return "testvcs"
+}
+
+func (t *testVCS) Init(webhookRouter *mux.Router) {
+	webhookRouter.HandleFunc("/testvcs", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello test")
+	}).Methods(http.MethodPost)
+}
+
+func TestWebHookSubRouter(t *testing.T) {
+	router := mux.NewRouter()
+	man := NewManager(&config.VcsConfig{
+		Github: &config.GithubConfig{},
+	}, router)
+	man.services["testvcs"] = &testVCS{}
+	man.initRouter(router)
+
+	r := httptest.NewRequest(http.MethodPost, "/webhook/testvcs", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "hello test", string(body))
+
+	r = httptest.NewRequest(http.MethodPost, "/webhook/github", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	resp = w.Result()
+	body, _ = ioutil.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "", string(body))
+}


### PR DESCRIPTION
VCS manage now passes a prefixed `/webhook` router to `RepositoryService` implementations.

Fixes #29 